### PR TITLE
Mokr create checks if files exists before it writes fixture/data templates. Also some typo fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ This will give you the mokr cli tools which can scaffold out and create your fir
 $ mokr init
 ```
 
-This will setup the fixtures and data directories, as well as install [Faker](https://github.com/Marak/faker.js) which is a helpful tool for generating fake data for your fixtures.  Now that the directories are in place you can greate your first fixture:
+This will setup the fixtures and data directories, as well as install [Faker](https://github.com/Marak/faker.js) which is a helpful tool for generating fake data for your fixtures.  Now that the directories are in place you can create your first fixture:
 
 ```
 $ mokr create my-awesome-fixture
 ```
 
-This will create two files for you, `./mokr/fixtures/my-awesome-fixture.js` and `./mokr/data/my-awesome-fixture.js`.  The file in data is where your mock data should live.  This is stored separatly from the fixture itself to allow for reuse across other fixtures, there is no need to use this file if you alreay have the mock data you need.  The fixture file should export `up` and `down` methods which should implement setup and teardown logic.
+This will create two files for you, `./mokr/fixtures/my-awesome-fixture.js` and `./mokr/data/my-awesome-fixture.js`.  The file in data is where your mock data should live.  This is stored separately from the fixture itself to allow for reuse across other fixtures, there is no need to use this file if you already have the mock data you need.  The fixture file should export `up` and `down` methods which should implement setup and teardown logic.
 
 ## Using Your Fixtures
 
@@ -32,7 +32,7 @@ To use the fixtures you have setup all you have to do is run them:
 $ mokr up my-awesome-fixture
 ```
 
-This will run through the fixtures of the given name(s).  To see which fixtrues have been run you can always check the fixture status with:
+This will run through the fixtures of the given name(s).  To see which fixtures have been run you can always check the fixture status with:
 
 ```
 $ mokr status
@@ -69,7 +69,7 @@ module.exports.up = function() {
 				post: post
 			}
 		}, function() {
-			
+
 		}.bind(this));
 	}.bind(this));
 };

--- a/bin/mokr-clean
+++ b/bin/mokr-clean
@@ -33,6 +33,6 @@ fs.unlink(stateFile, function(err) {
 		if (err) {
 			return logger.error(err);
 		}
-		logger.notice('Moker status has been cleaned');
+		logger.notice('Mokr status has been cleaned');
 	});
 });

--- a/bin/mokr-create
+++ b/bin/mokr-create
@@ -75,7 +75,6 @@ state.load(function(err) {
 	} else {
 		logger.notice('Data ' + dataPath + ' already exists');
 	}
-	fs.writeFileSync(dataPath, dataTmpl);
 
 	// Resave the state
 	state.add(name);

--- a/bin/mokr-create
+++ b/bin/mokr-create
@@ -32,11 +32,11 @@ if (app.args.length === 1) {
 var fixtureTmpl = [
   'var data = require(\'../data/' + name + '\');',
   '',
-  'module.exports.up = function(next) {',
+  'module.exports.up = function (next) {',
   '	next();',
   '};',
   '',
-  'module.exports.down = function(next) {',
+  'module.exports.down = function (next) {',
   '	next();',
   '};',
   ''

--- a/bin/mokr-create
+++ b/bin/mokr-create
@@ -62,10 +62,19 @@ state.load(function(err) {
 
 	var fixturePath = path.join('mokr', 'fixtures', name + '.js');
 	logger.notice('Writing fixture ' + fixturePath);
-	fs.writeFileSync(fixturePath, fixtureTmpl);
+	if (!fs.exists(fixturePath)) {
+		fs.writeFileSync(fixturePath, fixtureTmpl);
+	} else {
+		logger.notice('Fixture ' + fixturePath + ' already exists');
+	}
 
 	var dataPath = path.join('mokr', 'data', name + '.js');
 	logger.notice('Writing data ' + dataPath);
+	if (!fs.exists(dataPath)) {
+		fs.writeFileSync(dataPath, fixtureTmpl);
+	} else {
+		logger.notice('Data ' + dataPath + ' already exists');
+	}
 	fs.writeFileSync(dataPath, dataTmpl);
 
 	// Resave the state

--- a/bin/mokr-create
+++ b/bin/mokr-create
@@ -62,7 +62,7 @@ state.load(function(err) {
 
 	var fixturePath = path.join('mokr', 'fixtures', name + '.js');
 	logger.notice('Writing fixture ' + fixturePath);
-	if (!fs.exists(fixturePath)) {
+	if (!fs.existsSync(fixturePath)) {
 		fs.writeFileSync(fixturePath, fixtureTmpl);
 	} else {
 		logger.notice('Fixture ' + fixturePath + ' already exists');
@@ -70,8 +70,8 @@ state.load(function(err) {
 
 	var dataPath = path.join('mokr', 'data', name + '.js');
 	logger.notice('Writing data ' + dataPath);
-	if (!fs.exists(dataPath)) {
-		fs.writeFileSync(dataPath, fixtureTmpl);
+	if (!fs.existsSync(dataPath)) {
+		fs.writeFileSync(dataPath, dataTmpl);
 	} else {
 		logger.notice('Data ' + dataPath + ' already exists');
 	}

--- a/bin/mokr-init
+++ b/bin/mokr-init
@@ -48,7 +48,7 @@ state.load(function(err) {
 });
 
 function createMokrStuff() {
-	
+
 	logger.notice('Installing faker');
 	exec('npm install --save faker', {
 		cwd: cwd
@@ -57,7 +57,7 @@ function createMokrStuff() {
 			logger.notice(stdout);
 			logger.error(err);
 		}
-		
+
 		logger.notice(chalk.white('Creating ./mokr'));
 		fs.mkdir('./mokr', function(err) {
 			if (err) {
@@ -80,7 +80,7 @@ function createMokrStuff() {
 						if (err) {
 							return logger.error(err);
 						}
-						logger.notice('Moker is ready to go!');
+						logger.notice('Mokr is ready to go!');
 						logger.notice('Now run `mokr create <name>` to strea a fixture.');
 					});
 				});

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,7 +8,7 @@ module.exports = function(app) {
 		if (app.debug) {
 			level = 'debug';
 		} else if (app.silent) {
-			level = 'emergemcy';
+			level = 'emergency';
 		}
 
 		// Setup logger


### PR DESCRIPTION
After I got my first fixture up and running, i made a second one manually (totally forgot about mokr create <fixture>). when I did run mokr create <fixture> , my fixture and data files were overwritten. Super easy to recover them, just thought this change might be nice.

In that situation, and on this branch, mokr sees the fixture and data files already exist, then logs a notice but continues to save the fixture for command line mokr use.
